### PR TITLE
Disable widget command execution if widgets are `disabled`

### DIFF
--- a/Sidebar.widget/Battery.widget/index.coffee
+++ b/Sidebar.widget/Battery.widget/index.coffee
@@ -102,36 +102,35 @@ render: (output) ->
 
 # Update the rendered output.
 update: (output, domEl) ->
-
   # Get our main DIV.
   div = $(domEl)
-
-  if @options.widgetEnable
-    # Get our pieces.
-    values = output.slice(0,-1).split(" ")
-
-    # Initialize our HTML.
-    batteryHTML = ''
-    div.find('.bar').css('width', values[0])
-    div.find('.time').html(values[1])
-
-    if values[0] != "NA"
-      div.animate({ opacity: 1 }, 250)
-      if parseInt(values[0]) < 10
-        div.find('.bar').css('background-color', 'rgba(255,0,0,0.5)')
-      else
-        div.find('.bar').css('background-color', '')
-
-      if values[2] == 'charging'
-        div.find('.icon').html('<svg viewBox="0 0 6 12"><g transform="translate(-1332.000000, -610.000000)"><path d="M1338,610 L1332,616 L1335,617 L1332,622 L1338,616 L1335,615 L1338,610 Z"></path></g></svg>').show()
-      else
-        div.find('.icon').hide()
-    else
-      div.animate({ opacity: 0 }, 250)
-      div.parent('div').css('margin-top', '-1px')
-
-    # Sort out flex-box positioning.
-    div.parent('div').css('order', '7')
-    div.parent('div').css('flex', '0 1 auto')
-  else
+  if options.widgetEnable is false
     div.remove()
+    return
+
+  # Get our pieces.
+  values = output.slice(0,-1).split(" ")
+
+  # Initialize our HTML.
+  batteryHTML = ''
+  div.find('.bar').css('width', values[0])
+  div.find('.time').html(values[1])
+
+  if values[0] != "NA"
+    div.animate({ opacity: 1 }, 250)
+    if parseInt(values[0]) < 10
+      div.find('.bar').css('background-color', 'rgba(255,0,0,0.5)')
+    else
+      div.find('.bar').css('background-color', '')
+
+    if values[2] == 'charging'
+      div.find('.icon').html('<svg viewBox="0 0 6 12"><g transform="translate(-1332.000000, -610.000000)"><path d="M1338,610 L1332,616 L1335,617 L1332,622 L1338,616 L1335,615 L1338,610 Z"></path></g></svg>').show()
+    else
+      div.find('.icon').hide()
+  else
+    div.animate({ opacity: 0 }, 250)
+    div.parent('div').css('margin-top', '-1px')
+
+  # Sort out flex-box positioning.
+  div.parent('div').css('order', '7')
+  div.parent('div').css('flex', '0 1 auto')

--- a/Sidebar.widget/Battery.widget/index.coffee
+++ b/Sidebar.widget/Battery.widget/index.coffee
@@ -11,7 +11,7 @@ options =
 
 command: "osascript 'Sidebar.widget/Battery.widget/battery.applescript'"
 
-refreshFrequency: options.widgetEnable is false ? false : '1s'
+refreshFrequency: if options.widgetEnable then '1s' else false
 
 style: """
 

--- a/Sidebar.widget/Battery.widget/index.coffee
+++ b/Sidebar.widget/Battery.widget/index.coffee
@@ -11,7 +11,7 @@ options =
 
 command: "osascript 'Sidebar.widget/Battery.widget/battery.applescript'"
 
-refreshFrequency: '1s'
+refreshFrequency: options.widgetEnable is false ? false : '1s'
 
 style: """
 

--- a/Sidebar.widget/Calendar.widget/index.coffee
+++ b/Sidebar.widget/Calendar.widget/index.coffee
@@ -21,7 +21,7 @@ options =
   # Choose color theme.
   widgetTheme: "dark"                   # dark | light
 
-refreshFrequency: options.widgetEnable is false ? false : '1h'
+refreshFrequency: if options.widgetEnable then '1h' else false
 
 command: options.firstDay
 

--- a/Sidebar.widget/Calendar.widget/index.coffee
+++ b/Sidebar.widget/Calendar.widget/index.coffee
@@ -21,7 +21,7 @@ options =
   # Choose color theme.
   widgetTheme: "dark"                   # dark | light
 
-refreshFrequency: '1h'
+refreshFrequency: options.widgetEnable is false ? false : '1h'
 
 command: options.firstDay
 

--- a/Sidebar.widget/Calendar.widget/index.coffee
+++ b/Sidebar.widget/Calendar.widget/index.coffee
@@ -162,18 +162,17 @@ updateBody: (rows, table) ->
         cell.addClass("grey")
 
 update: (output, domEl) ->
-
   div = $(domEl)
-
-  if @options.widgetEnable
-    rows = output.split("\n")
-    table = div.find("table")
-
-    @updateHeader rows, table
-    @updateBody rows, table
-
-    # Sort out flex-box positioning.
-    div.parent('div').css('order', '5')
-    div.parent('div').css('flex', '0 1 auto')
-  else
+  if options.widgetEnable is false
     div.remove()
+    return
+
+  rows = output.split("\n")
+  table = div.find("table")
+
+  @updateHeader rows, table
+  @updateBody rows, table
+
+  # Sort out flex-box positioning.
+  div.parent('div').css('order', '5')
+  div.parent('div').css('flex', '0 1 auto')

--- a/Sidebar.widget/Next Event.widget/index.coffee
+++ b/Sidebar.widget/Next Event.widget/index.coffee
@@ -8,7 +8,7 @@ options =
 
 command: "osascript 'Sidebar.widget/Next Event.widget/Next Event.applescript'"
 
-refreshFrequency: options.widgetEnable is false ? false : '1m'
+refreshFrequency: if options.widgetEnable then '1m' else false
 
 style: """
   white05 = rgba(white,0.5)

--- a/Sidebar.widget/Next Event.widget/index.coffee
+++ b/Sidebar.widget/Next Event.widget/index.coffee
@@ -8,7 +8,7 @@ options =
 
 command: "osascript 'Sidebar.widget/Next Event.widget/Next Event.applescript'"
 
-refreshFrequency: '1m'
+refreshFrequency: options.widgetEnable is false ? false : '1m'
 
 style: """
   white05 = rgba(white,0.5)
@@ -75,36 +75,35 @@ render: (output) ->
 
 # Update the rendered output.
 update: (output, domEl) ->
-
   # Get our main DIV.
   div = $(domEl)
-
-  if @options.widgetEnable
-    # Get our pieces.
-    values = output.slice(0,-1).split("^")
-
-    # Initialize main HTML.
-    NextEventHTML = ''
-    div.find('.time').html(values[0])
-    div.find('.eventName').html(values[1])
-    div.find('.meta').html(values[2])
-
-    if values[0] == 'No Events'
-      div.find('.wrapper').css('display', 'none')
-      div.parent('div').css('margin-top', '-1px')
-    else if values[0] == 'icalbuddy'
-      div.find('.time').css('display', 'none')
-      div.find('.text').html("Please install icalBuddy.<br />'brew install ical-buddy' seems like a good idea.").css('white-space', 'normal').css('text-align', 'center').css('margin-right', '0')
-    else
-      div.find('.wrapper').css('display', 'block')
-
-    if parseInt(values[2]) != 0
-      div.find('.meta').css('display', 'block')
-    else
-      div.find('.meta').css('display', 'none')
-
-    # Sort out flex-box positioning.
-    div.parent('div').css('order', '4')
-    div.parent('div').css('flex', '0 1 auto')
-  else
+  if options.widgetEnable is false
     div.remove()
+    return
+
+  # Get our pieces.
+  values = output.slice(0,-1).split("^")
+
+  # Initialize main HTML.
+  NextEventHTML = ''
+  div.find('.time').html(values[0])
+  div.find('.eventName').html(values[1])
+  div.find('.meta').html(values[2])
+
+  if values[0] == 'No Events'
+    div.find('.wrapper').css('display', 'none')
+    div.parent('div').css('margin-top', '-1px')
+  else if values[0] == 'icalbuddy'
+    div.find('.time').css('display', 'none')
+    div.find('.text').html("Please install icalBuddy.<br />'brew install ical-buddy' seems like a good idea.").css('white-space', 'normal').css('text-align', 'center').css('margin-right', '0')
+  else
+    div.find('.wrapper').css('display', 'block')
+
+  if parseInt(values[2]) != 0
+    div.find('.meta').css('display', 'block')
+  else
+    div.find('.meta').css('display', 'none')
+
+  # Sort out flex-box positioning.
+  div.parent('div').css('order', '4')
+  div.parent('div').css('flex', '0 1 auto')

--- a/Sidebar.widget/Playbox.widget/index.coffee
+++ b/Sidebar.widget/Playbox.widget/index.coffee
@@ -8,7 +8,7 @@ options =
 
 command: "osascript 'Sidebar.widget/Playbox.widget/as/Get Current Track.applescript'"
 
-refreshFrequency: '1s'
+refreshFrequency: options.widgetEnable is false ? false : '1s'
 
 style: """
 

--- a/Sidebar.widget/Playbox.widget/index.coffee
+++ b/Sidebar.widget/Playbox.widget/index.coffee
@@ -8,7 +8,7 @@ options =
 
 command: "osascript 'Sidebar.widget/Playbox.widget/as/Get Current Track.applescript'"
 
-refreshFrequency: options.widgetEnable is false ? false : '1s'
+refreshFrequency: if options.widgetEnable then '1s' else false
 
 style: """
 

--- a/Sidebar.widget/Playbox.widget/index.coffee
+++ b/Sidebar.widget/Playbox.widget/index.coffee
@@ -81,43 +81,42 @@ render: (output) ->
 
 # Update the rendered output.
 update: (output, domEl) ->
-
   # Get our main DIV.
   div = $(domEl)
-
-  if @options.widgetEnable
-    # Get our pieces.
-    values = output.slice(0,-1).split(" ~ ")
-
-    # Initialize our HTML.
-    medianowHTML = ''
-
-    # Progress bar things.
-    tDuration = values[4]
-    tPosition = values[5]
-    tArtwork = values[6]
-    tWidth = div.width();
-    tCurrent = (tPosition / tDuration) * tWidth
-
-    currArt = div.find('.art').css('background-image').split('/').pop().slice(0,-1)
-
-    if values[0] == 'NA'
-      div.animate({ opacity: 0 }, 250)
-      setTimeout(div.hide(1), 1)
-    else
-      div.animate({ opacity: 1 }, 250, "swing", setTimeout(div.show(1), 1))
-      div.find('.song').html(values[1])
-      div.find('.artist').html(values[0])
-      div.find('.album').html(values[2])
-      div.find('.progress').css width: tCurrent
-      if tArtwork isnt currArt
-        if tArtwork =='NA'
-          div.find('.art').css('background-image', 'url(Sidebar.widget/Playbox.widget/as/default.png)')
-        else
-          div.find('.art').css('background-image', 'url('+tArtwork+')')
-
-    # Sort out flex-box positioning.
-    div.parent('div').css('order', '7')
-    div.parent('div').css('flex', '0 1 auto')
-  else
+  if options.widgetEnable is false
     div.remove()
+    return
+
+  # Get our pieces.
+  values = output.slice(0,-1).split(" ~ ")
+
+  # Initialize our HTML.
+  medianowHTML = ''
+
+  # Progress bar things.
+  tDuration = values[4]
+  tPosition = values[5]
+  tArtwork = values[6]
+  tWidth = div.width();
+  tCurrent = (tPosition / tDuration) * tWidth
+
+  currArt = div.find('.art').css('background-image').split('/').pop().slice(0,-1)
+
+  if values[0] == 'NA'
+    div.animate({ opacity: 0 }, 250)
+    setTimeout(div.hide(1), 1)
+  else
+    div.animate({ opacity: 1 }, 250, "swing", setTimeout(div.show(1), 1))
+    div.find('.song').html(values[1])
+    div.find('.artist').html(values[0])
+    div.find('.album').html(values[2])
+    div.find('.progress').css width: tCurrent
+    if tArtwork isnt currArt
+      if tArtwork =='NA'
+        div.find('.art').css('background-image', 'url(Sidebar.widget/Playbox.widget/as/default.png)')
+      else
+        div.find('.art').css('background-image', 'url('+tArtwork+')')
+
+  # Sort out flex-box positioning.
+  div.parent('div').css('order', '7')
+  div.parent('div').css('flex', '0 1 auto')

--- a/Sidebar.widget/Time Elapsed.widget/index.coffee
+++ b/Sidebar.widget/Time Elapsed.widget/index.coffee
@@ -79,19 +79,19 @@ render: (output) ->
 
 # Update the rendered output.
 update: (output, domEl) ->
-
   # Get our main DIV.
   div = $(domEl)
 
-  if @options.widgetEnable
-    # Get our pieces.
-    values = output.slice(0,-1).split(" ")
-
-    # Initialize our HTML.
-    elapsedHTML = ''
-
-    # Sort out flex-box positioning.
-    div.parent('div').css('order', '1')
-    div.parent('div').css('flex', '0 1 auto')
-  else
+  if @options.widgetEnable is false
     div.remove()
+    return
+
+  # Get our pieces.
+  values = output.slice(0,-1).split(" ")
+
+  # Initialize our HTML.
+  elapsedHTML = ''
+
+  # Sort out flex-box positioning.
+  div.parent('div').css('order', '1')
+  div.parent('div').css('flex', '0 1 auto')

--- a/Sidebar.widget/Time Elapsed.widget/index.coffee
+++ b/Sidebar.widget/Time Elapsed.widget/index.coffee
@@ -11,7 +11,7 @@ options =
 
 command: "osascript 'Sidebar.widget/Time Elapsed.widget/Time Elapsed.applescript' \"#{options.theDate}\""
 
-refreshFrequency: options.widgetEnable is false ? false : '1h'
+refreshFrequency: if options.widgetEnable then '1h' else false
 
 style: """
   white1 = rgba(white,1)

--- a/Sidebar.widget/Time Elapsed.widget/index.coffee
+++ b/Sidebar.widget/Time Elapsed.widget/index.coffee
@@ -11,7 +11,7 @@ options =
 
 command: "osascript 'Sidebar.widget/Time Elapsed.widget/Time Elapsed.applescript' \"#{options.theDate}\""
 
-refreshFrequency: '1h'
+refreshFrequency: options.widgetEnable is false ? false : '1h'
 
 style: """
   white1 = rgba(white,1)

--- a/Sidebar.widget/WeatherNow.widget/index.coffee
+++ b/Sidebar.widget/WeatherNow.widget/index.coffee
@@ -13,7 +13,7 @@ options =
 appearance =
   iconSet       : 'original'        # "original" for the original icons
 
-refreshFrequency: '10m'             # Update every 10 minutes
+refreshFrequency: options.widgetEnable is false ? false: '10m' # Update every 10 minutes
 
 style: """
   white1    = rgba(white,1)

--- a/Sidebar.widget/WeatherNow.widget/index.coffee
+++ b/Sidebar.widget/WeatherNow.widget/index.coffee
@@ -13,7 +13,7 @@ options =
 appearance =
   iconSet       : 'original'        # "original" for the original icons
 
-refreshFrequency: options.widgetEnable is false ? false: '10m' # Update every 10 minutes
+refreshFrequency: if options.widgetEnable then '10m' else false # Update every 10 minutes
 
 style: """
   white1    = rgba(white,1)

--- a/Sidebar.widget/WeatherNow.widget/index.coffee
+++ b/Sidebar.widget/WeatherNow.widget/index.coffee
@@ -105,28 +105,28 @@ render: -> """
 
 update: (output, domEl) ->
   @$domEl = $(domEl)
-
-  if @options.widgetEnable
-    data    = JSON.parse(output)
-    channel = data?.query?.results?.channel
-    return @renderError(data) unless channel
-
-    if channel.title == "Yahoo! Weather - Error"
-      return @renderError(data, channel.item?.title)
-
-    @renderCurrent channel
-
-    @$domEl.find('.error').remove()
-    @$domEl.children().show()
-
-    # Sort out flex-box positioning.
-    $(domEl).parent('div').css('order', '3')
-    $(domEl).parent('div').css('flex', '0 1 auto')
-  else
+  if options.widgetEnable is false
     @$domEl.remove()
+    return
+
+  data = JSON.parse(output)
+  channel = data?.query?.results?.channel
+  return @renderError(data) unless channel
+
+  if channel.title == "Yahoo! Weather - Error"
+    return @renderError(data, channel.item?.title)
+
+  @renderCurrent channel
+
+  @$domEl.find('.error').remove()
+  @$domEl.children().show()
+
+  # Sort out flex-box positioning.
+  $(domEl).parent('div').css('order', '3')
+  $(domEl).parent('div').css('flex', '0 1 auto')
 
 renderCurrent: (channel) ->
-  weather  = channel.item
+  weather = channel.item
   location = channel.location
 
   el = @$domEl.find('.wrapper')

--- a/Sidebar.widget/WorldClock.widget/index.coffee
+++ b/Sidebar.widget/WorldClock.widget/index.coffee
@@ -19,7 +19,7 @@ options =
 
 command: "osascript Sidebar.widget/WorldClock.widget/WorldClock.applescript '#{options.locations}' '#{options.cityNames}' #{options.timeFormat}"
 
-refreshFrequency: '1m'
+refreshFrequency: options.widgetEnable is false ? false: '1m'
 
 style: """
   // Let's do theming first.

--- a/Sidebar.widget/WorldClock.widget/index.coffee
+++ b/Sidebar.widget/WorldClock.widget/index.coffee
@@ -78,38 +78,36 @@ render: -> """
 
 # Update the rendered output.
 update: (output, domEl) ->
-
-  # Get our main DIV.
   div = $(domEl)
-
-  if @options.widgetEnable
-    # Get our timezones and times.
-    zones=output.split(";")
-
-    # Initialize our HTML.
-    timeHTML = ''
-
-    # Loop through each of the time zones.
-    for zone, idx in zones
-
-      # If the zone is not empty (e.g. the last newline), let's add it to the HTML.
-      if zone != ''
-
-        # Split the timezone from the time.
-        values = zone.split("~")
-
-        # Create the DIVs for each timezone/time. The last item is unique in that we don't want to display the border.
-        # if idx < zones.length - 2
-        timeHTML = timeHTML + "<div class='box'><div class='time'>" + values[1] + "</div><div class='timezone'>" + values[0] + "</div></div>"
-        # else
-          #timeHTML = timeHTML + "<div class='lastbox'><div class='time'>" + values[1] + "</div><div class='timezone'>" + values[0] + "</div></div>"
-
-    # Set the HTML of our main DIV.
-    div.html("<div class='wrapper'>" + timeHTML + "</div>")
-    # div.html("<div class='wrapper'>" + output + "</div>")
-
-    # Sort out flex-box positioning.
-    div.parent('div').css('order', '6')
-    div.parent('div').css('flex', '0 1 auto')
-  else
+  if options.widgetEnable is false
     div.remove()
+    return
+
+  # Get our timezones and times.
+  zones = output.split(";")
+
+  # Initialize our HTML.
+  timeHTML = ''
+
+  # Loop through each of the time zones.
+  for zone, idx in zones
+
+    # If the zone is not empty (e.g. the last newline), let's add it to the HTML.
+    if zone != ''
+
+      # Split the timezone from the time.
+      values = zone.split("~")
+
+      # Create the DIVs for each timezone/time. The last item is unique in that we don't want to display the border.
+      # if idx < zones.length - 2
+      timeHTML = timeHTML + "<div class='box'><div class='time'>" + values[1] + "</div><div class='timezone'>" + values[0] + "</div></div>"
+  # else
+  #timeHTML = timeHTML + "<div class='lastbox'><div class='time'>" + values[1] + "</div><div class='timezone'>" + values[0] + "</div></div>"
+
+  # Set the HTML of our main DIV.
+  div.html("<div class='wrapper'>" + timeHTML + "</div>")
+  # div.html("<div class='wrapper'>" + output + "</div>")
+
+  # Sort out flex-box positioning.
+  div.parent('div').css('order', '6')
+  div.parent('div').css('flex', '0 1 auto')

--- a/Sidebar.widget/WorldClock.widget/index.coffee
+++ b/Sidebar.widget/WorldClock.widget/index.coffee
@@ -19,7 +19,7 @@ options =
 
 command: "osascript Sidebar.widget/WorldClock.widget/WorldClock.applescript '#{options.locations}' '#{options.cityNames}' #{options.timeFormat}"
 
-refreshFrequency: options.widgetEnable is false ? false: '1m'
+refreshFrequency: if options.widgetEnable then '1m' else false
 
 style: """
   // Let's do theming first.

--- a/Sidebar.widget/index.coffee
+++ b/Sidebar.widget/index.coffee
@@ -15,6 +15,7 @@ render: (output) ->
 
   if @widgetEnable is false
     $(domEl).find('.widget').remove()
+    return
 
   """
   <style>


### PR DESCRIPTION
This PR disables the execution of the commands belonging to the widgets if their `options.widgetEnabled` property is set to `false`.

Furthermore I moved the check in the `update` methods for disabled widgets into a guard clause for better readability